### PR TITLE
Add ability to use zuul format to specify the platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ easy-sauce -c path/to/config.json
 If you're testing an npm package, you can skip the external configuration file and specify your configuration options directly in `package.json` file under the `"easySauce"` key:
 
 
-```js
+```json
 {
   "name": "my-package",
   "version": "1.0.0",
@@ -135,7 +135,7 @@ If you're testing an npm package, you can skip the external configuration file a
 }
 ```
 
-In the above example, the `"tests"` command is also set to `easy-sauce`, so now you can run your tests via npm:
+In the above example, the `"test"` command is also set to `easy-sauce`, so now you can run your tests via npm:
 
 ```
 npm test
@@ -143,6 +143,22 @@ npm test
 
 This setup makes it very easy to integrate with services like Travis CI that use a lot of npm conventions as their default.
 
+Platforms can also be specified using the "zuul" [format](https://github.com/defunctzombie/zuul/wiki/Zuul.yml#browsers-required). For example:
+
+```json
+{
+  "platforms": [
+    {
+      "name": "internet explorer",
+      "version": "oldest..latest"
+    },
+    {
+      "name": "chrome",
+      "version": ["oldest", "latest"]
+    }
+  ]
+}
+```
 
 #### Keeping your Sauce Labs credentials secret
 

--- a/lib/easy-sauce.js
+++ b/lib/easy-sauce.js
@@ -3,6 +3,7 @@
 const connect = require('connect');
 const EventEmitter = require('events');
 const request = require('request');
+const sauceBrowsers = require('sauce-browsers');
 const serveStatic = require('serve-static');
 const messages = require('./messages');
 const services = require('./services');
@@ -47,19 +48,31 @@ class EasySauce {
   }
 
 
+  scoutBrowsers() {
+    return sauceBrowsers(this.opts.platforms).then((platforms) => {
+      this.opts.platforms = platforms.map((el) => [
+        el.os, el.api_name, el.short_version
+      ]);
+    });
+  }
+
+
   validateInput() {
     return new Promise((resolve, reject) => {
       // Validates the platforms list before making any API calls.
       if (!this.opts.platforms) {
-        reject(new Error(messages('BROWSERS_REQUIRED')));
+        return reject(new Error(messages('BROWSERS_REQUIRED')));
       }
       // Ensures Sauce Labs credentials are set.
-      else if (!this.opts.username || !this.opts.key) {
+      if (!this.opts.username || !this.opts.key) {
         return reject(new Error(messages('CREDENTIALS_REQUIRED')));
       }
-      else {
-        resolve();
-      }
+      // Allows platforms to be specified in "zuul" format.
+      const value = !Array.isArray(this.opts.platforms[0])
+        ? this.scoutBrowsers()
+        : undefined;
+
+      resolve(value);
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "minimist": "^1.2.0",
     "ngrok": "^2.2.6",
     "request": "^2.81.0",
+    "sauce-browsers": "^1.0.0",
     "sauce-connect-launcher": "^1.2.0",
     "serve-static": "^1.12.1"
   },


### PR DESCRIPTION
As discussed in #10 this adds the ability to use "zuul" [format](https://github.com/defunctzombie/zuul/wiki/Zuul.yml#browsers-required) to specify the platforms.

Closes #10.